### PR TITLE
Fix: アバター横のユーザー名高さ中央揃え

### DIFF
--- a/app/views/shared/_avatar_name.html.erb
+++ b/app/views/shared/_avatar_name.html.erb
@@ -1,5 +1,5 @@
-<div class="flex items-center">
-  <%= link_to user_path(user) do %>
+<%= link_to user_path(user) do %>
+  <div class="flex items-center">
     <%= render partial: 'shared/avatar', locals: { user: user } %><%= user.name %>
-  <% end %>
-</div>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
#150 に基づいて作業
