### PR TITLE
フォローユーザーの投稿を見るためのタイムラインを実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false
+}

--- a/app/controllers/promotions_controller.rb
+++ b/app/controllers/promotions_controller.rb
@@ -57,13 +57,7 @@ class PromotionsController < ApplicationController
   end
 
   def index
-    # フォロー中ユーザーの投稿で絞り込み
-    promotions = if params[:follow] == "on"
-      Promotion.where(user_id: current_user.followings.ids)
-    else
-      Promotion
-    end
-    @q = promotions.ransack(params[:q])
+    @q = Promotion.ransack(params[:q])
     @promotions = @q.result(distinct: true).includes(:user, :content, :group).order(created_at: :desc).page(params[:page])
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,13 +3,7 @@ class RequestsController < ApplicationController
   before_action :set_request, only: %i[edit update destroy]
 
   def index
-    # フォロー中ユーザーの投稿で絞り込み
-    requests = if params[:follow] == "on"
-      Request.where(user_id: current_user.followings.ids)
-    else
-      Request
-    end
-    @q = requests.ransack(params[:q])
+    @q = Request.ransack(params[:q])
     @requests = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
   end
 

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -6,11 +6,11 @@ class TimelinesController < ApplicationController
 
   def requests
     ids = Request.includes(:user).select{ |x| current_user.following?(x.user) }.pluck(:id)
-    @requests = Request.where(id: ids).includes(:user).page(params[:page])
+    @requests = Request.where(id: ids).includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def promotions
     ids = Promotion.includes(:user).select{ |x| current_user.following?(x.user) }.pluck(:id)
-    @promotions = Promotion.where(id: ids).includes(:user).page(params[:page])
+    @promotions = Promotion.where(id: ids).includes(:user, :content, :group).order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -1,0 +1,16 @@
+class TimelinesController < ApplicationController
+  def show
+    ids = Request.includes(:user).select{ |x| current_user.following?(x.user) }.pluck(:id)
+    @requests = Request.where(id: ids).includes(:user).page(params[:page])
+  end
+
+  def requests
+    ids = Request.includes(:user).select{ |x| current_user.following?(x.user) }.pluck(:id)
+    @requests = Request.where(id: ids).includes(:user).page(params[:page])
+  end
+
+  def promotions
+    ids = Promotion.includes(:user).select{ |x| current_user.following?(x.user) }.pluck(:id)
+    @promotions = Promotion.where(id: ids).includes(:user).page(params[:page])
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_to(mypage_path, notice: 'ログインしました')
+      redirect_back_or_to(timeline_path, notice: 'ログインしました')
     else
       flash.now[:alert] = 'ログインに失敗しました'
       render :new, status: :unprocessable_entity

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,6 +7,12 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: 'btn'} do %>
-  <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: 'btn btn-active'} %>
+<% if request.url.include?("timeline") %>
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: 'btn', data:{turbo_method: :post}} do %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: 'btn btn-active', data: {turbo_method: :post}} %>
+  <% end %>
+<% else %>
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: 'btn'} do %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: 'btn btn-active'} %>
+  <% end %>
 <% end %>

--- a/app/views/promotions/index.html.erb
+++ b/app/views/promotions/index.html.erb
@@ -8,12 +8,6 @@
       <%= f.select :existence_eq, Promotion.existences_i18n.invert.map {|k, v| [k, Promotion.existences[v]]}, {include_blank: '実在／キャラクター'}, {class: "select select-bordered w-48 m-2"} %>
       <%= f.select :decade_eq, Promotion.decades_i18n.invert.map {|k, v| [k, Promotion.decades[v]]}, {include_blank: '年齢'}, {class: "select select-bordered w-48 m-2"} %>
       <%= f.select :gender_eq, Promotion.genders_i18n.invert.map {|k, v| [k, Promotion.genders[v]]}, {include_blank: '性別'}, {class: "select select-bordered w-48 m-2"} %>
-      <% if logged_in? %>
-        <label class="cursor-pointer">
-          <span class="label-text">フォロー中のユーザーによる投稿</span> 
-          <input name="follow" type="checkbox" class="checkbox checkbox-primary" />
-        </label>
-      <% end %>
       <%= f.submit class: "btn my-2" %>
     <% end %>
   </div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -8,12 +8,6 @@
       <%= f.select :existence_eq, Request.existences_i18n.invert.map {|k, v| [k, Request.existences[v]]}, {include_blank: '実在／キャラクター'}, {class: "select select-bordered w-48 m-2"} %>
       <%= f.select :decade_eq, Request.decades_i18n.invert.map {|k, v| [k, Request.decades[v]]}, {include_blank: '年齢'}, {class: "select select-bordered w-48 m-2"} %>
       <%= f.select :gender_eq, Request.genders_i18n.invert.map {|k, v| [k, Request.genders[v]]}, {include_blank: '性別'}, {class: "select select-bordered w-48 m-2"} %>
-      <% if logged_in? %>
-        <label class="cursor-pointer">
-          <span class="label-text">フォロー中のユーザーによる投稿</span> 
-          <input name="follow" type="checkbox" class="checkbox checkbox-primary" />
-        </label>
-      <% end %>
       <%= f.submit class: "btn my-2" %>
     <% end %>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,6 +8,8 @@
         <% unless logged_in? %>
           <li><%= link_to "ログイン", login_path %></li>
           <li><%= link_to "ユーザー登録", new_user_path %></li>
+        <% else %>
+          <li><%= link_to "タイムライン", timeline_path %></li>
         <% end %>
         <li><%= link_to t('menu.request'), requests_path %></li>
         <li><%= link_to t('menu.promotion'), promotions_path %></li>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -68,7 +68,7 @@
     </div>
     <div class= "flex justify-center mt-16 content-center">
       <% if logged_in? %>
-        <%= link_to 'マイページへ', mypage_path, class: "btn text-lg mx-3" %>
+        <%= link_to 'タイムライン', timeline_path, class: "btn text-lg mx-3" %>
       <% else %>
         <%= link_to 'ログイン', login_path, class: "btn text-lg mx-3" %>
         <%= link_to '新規登録', new_user_path, class: "btn text-lg mx-3" %>

--- a/app/views/timelines/_promotion.html.erb
+++ b/app/views/timelines/_promotion.html.erb
@@ -1,18 +1,16 @@
-<%= turbo_frame_tag 'timeline' do %>
-  <%= turbo_frame_tag 'promotions_timeline' do %>
-    <% if promotions.count > 0 %>
-      <div class="flex flex-wrap">
-        <%= render promotions %>
+<%= turbo_frame_tag "promotions_timeline_page_#{promotions.current_page}" do %>
+  <% if promotions.count > 0 %>
+    <div class="flex flex-wrap">
+      <%= render promotions %>
+    </div>
+  <% else %>
+    <div class="alert my-5">
+      <div>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+        <span>フォローユーザーの投稿がありません</span>
       </div>
-    <% else %>
-      <div class="alert my-5">
-        <div>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-          <span>フォローユーザーの投稿がありません</span>
-        </div>
-      </div>
-      <%= link_to '全ての布教を見る', promotions_path, class: "btn" %>
-    <% end %>
-    <%= paginate promotions %>
+    </div>
+    <%= link_to '全ての布教を見る', promotions_path, class: "btn" %>
   <% end %>
+  <%= paginate promotions %>
 <% end %>

--- a/app/views/timelines/_promotion.html.erb
+++ b/app/views/timelines/_promotion.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag 'timeline' do %>
-  <%= turbo_frame_tag 'promotions' do %>
+  <%= turbo_frame_tag 'promotions_timeline' do %>
     <% if promotions.count > 0 %>
       <div class="flex flex-wrap">
         <%= render promotions %>
@@ -8,9 +8,10 @@
       <div class="alert my-5">
         <div>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-          <span>布教が見つかりませんでした</span>
+          <span>フォローユーザーの投稿がありません</span>
         </div>
       </div>
+      <%= link_to '全ての布教を見る', promotions_path, class: "btn" %>
     <% end %>
     <%= paginate promotions %>
   <% end %>

--- a/app/views/timelines/_promotion.html.erb
+++ b/app/views/timelines/_promotion.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag 'timeline' do %>
+  <%= turbo_frame_tag 'promotions' do %>
+    <% if promotions.count > 0 %>
+      <div class="flex flex-wrap">
+        <%= render promotions %>
+      </div>
+    <% else %>
+      <div class="alert my-5">
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+          <span>布教が見つかりませんでした</span>
+        </div>
+      </div>
+    <% end %>
+    <%= paginate promotions %>
+  <% end %>
+<% end %>

--- a/app/views/timelines/_request.html.erb
+++ b/app/views/timelines/_request.html.erb
@@ -1,18 +1,16 @@
-<%= turbo_frame_tag 'timeline' do %>
-  <%= turbo_frame_tag 'requests_timeline' do %>
-    <% if requests.count > 0 %>
-      <div class="flex flex-wrap">
-        <%= render requests %>
+<%= turbo_frame_tag 'requests_timeline' do %>
+  <% if requests.count > 0 %>
+    <div class="flex flex-wrap">
+      <%= render requests %>
+    </div>
+  <% else %>
+    <div class="alert my-5">
+      <div>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+        <span>フォローユーザーの投稿がありません</span>
       </div>
-    <% else %>
-      <div class="alert my-5">
-        <div>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-          <span>フォローユーザーの投稿がありません</span>
-        </div>
-      </div>
-      <%= link_to '全ての推し募集を見る', requests_path, class: "btn" %>
-    <% end %>
-    <%= paginate requests %>
+    </div>
+    <%= link_to '全ての推し募集を見る', requests_path, class: "btn" %>
   <% end %>
+  <%= paginate requests %>
 <% end %>

--- a/app/views/timelines/_request.html.erb
+++ b/app/views/timelines/_request.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag 'timeline' do %>
-  <%= turbo_frame_tag 'requests' do %>
+  <%= turbo_frame_tag 'requests_timeline' do %>
     <% if requests.count > 0 %>
       <div class="flex flex-wrap">
         <%= render requests %>
@@ -8,9 +8,10 @@
       <div class="alert my-5">
         <div>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-          <span>推し募集が見つかりませんでした</span>
+          <span>フォローユーザーの投稿がありません</span>
         </div>
       </div>
+      <%= link_to '全ての推し募集を見る', requests_path, class: "btn" %>
     <% end %>
     <%= paginate requests %>
   <% end %>

--- a/app/views/timelines/_request.html.erb
+++ b/app/views/timelines/_request.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag 'timeline' do %>
+  <%= turbo_frame_tag 'requests' do %>
+    <% if requests.count > 0 %>
+      <div class="flex flex-wrap">
+        <%= render requests %>
+      </div>
+    <% else %>
+      <div class="alert my-5">
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+          <span>推し募集が見つかりませんでした</span>
+        </div>
+      </div>
+    <% end %>
+    <%= paginate requests %>
+  <% end %>
+<% end %>

--- a/app/views/timelines/promotions.turbo_stream.erb
+++ b/app/views/timelines/promotions.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.update "timeline-tab" do %>
+  <%= link_to t('menu.request'), requests_timeline_path, class: 'tab tab-bordered', data: { turbo_frame: 'timeline', turbo_method: :post } %>
+  <%= link_to t('menu.promotion'), promotions_timeline_path, class: 'tab tab-bordered tab-active', data: { turbo_frame: 'timeline', turbo_method: :post } %>
+<% end %>
+
+<%= turbo_stream.update "timeline" do %>
+  <%= render partial: 'promotion', locals: { promotions: @promotions } %>
+<% end %>

--- a/app/views/timelines/requests.turbo_stream.erb
+++ b/app/views/timelines/requests.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.update "timeline-tab" do %>
+  <%= link_to t('menu.request'), requests_timeline_path, class: 'tab tab-bordered tab-active', data: { turbo_frame: 'timeline', turbo_method: :post } %>
+  <%= link_to t('menu.promotion'), promotions_timeline_path, class: 'tab tab-bordered', data: { turbo_frame: 'timeline', turbo_method: :post } %>
+<% end %>
+
+<%= turbo_stream.update "timeline" do %>
+  <%= render partial: 'request', locals: { requests: @requests } %>
+<% end %>

--- a/app/views/timelines/show.html.erb
+++ b/app/views/timelines/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:og_title, t('.title')) %>
+<% breadcrumb :timeline %>
+<div class="container mx-auto px-4 my-3">
+  <h1 class="text-center text-2xl font-bold text-primary mb-6">フォローユーザーの投稿</h1>
+  <div class="tabs ml-10">
+  <%= turbo_frame_tag 'timeline-tab' do %>
+    <%= link_to t('menu.request'), requests_timeline_path, class: 'tab tab-bordered tab-active', data: { turbo_frame: 'timeline', turbo_method: :post } %>
+    <%= link_to t('menu.promotion'), promotions_timeline_path, class: 'tab tab-bordered', data: { turbo_frame: 'timeline', turbo_method: :post } %>
+  <% end %>
+  </div>
+  <%= turbo_frame_tag 'timeline' do %>
+    <%= render partial: 'request', locals: { requests: @requests } %>
+  <% end %>
+</div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -12,6 +12,11 @@ crumb :mypage_edit do
   parent :mypage
 end
 
+crumb :timeline do
+  link t('breadcrumbs.timeline'), timeline_path
+  parent :root
+end
+
 crumb :requests do
   link t('breadcrumbs.requests'), requests_path
   parent :root

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     home: 'トップ'
     mypage: 'マイページ'
     mypage_edit: 'プロフィール編集'
+    timeline: 'タイムライン'
     requests: '推し募集'
     new: '新規作成'
     promotions: '布教'
@@ -35,6 +36,9 @@ ja:
     update:
       success: '変更内容を保存しました'
       fail: '変更内容を保存できませんでした'
+  timelines:
+    show:
+      title: 'タイムライン'
   users:
     new:
       title: 'ユーザー登録'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms_of_service', to: 'static_pages#terms_of_service'
   resource :mypage, only: %i[show edit update]
+  resource :timeline, only: %i[show] do
+    post 'requests', to: 'timelines#requests'
+    post 'promotions', to: 'timelines#promotions'
+  end
   resources :users, only: %i[new create show] do
     resource :relationships, only: %i[create destroy]
     get 'followings', to: 'relationships#followings', as: 'followings'


### PR DESCRIPTION
## 概要
フォロー中で絞り込み検索ができるようになっていたものの、しっくりこなかったので絞り込み機能は削除。
代わりにタイムラインではフォローユーザーの投稿を一覧で閲覧できるようにした。
